### PR TITLE
Add chat-user contact import script

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-08T05:52:41.846Z for PR creation at branch issue-13-83ec1ed74413 for issue https://github.com/konard/telegram-bot/issues/13

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-08T05:52:41.846Z for PR creation at branch issue-13-83ec1ed74413 for issue https://github.com/konard/telegram-bot/issues/13

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Scripts to work with telegram
 - Automatically partitions large exports into parts with prev/next navigation links
 - Uses [lino-arguments](https://github.com/link-foundation/lino-arguments) for CLI arguments and configuration
 - Extract all unique users from a chat (authors, joins/leaves, mentions, forwards)
+- Add visible chat users to Telegram contacts with a safe dry-run first
 - Uses only use-m for dynamic dependency loading (no package.json or npm install required)
 - Reads API credentials and defaults from a `.env` file (see `.env.example`)
 - Supports headless/automated operation via environment variables
@@ -88,6 +89,22 @@ Scripts to work with telegram
    - Shared contacts
 
    Saves users list to `data/{chat_username}/users.json`.
+
+   **Preview adding visible chat users to contacts:**
+   ```zsh
+   bun add-chat-users-to-contacts.mjs --chat @your_chat_username
+   ```
+   This scans visible participants and message users, skips bots/deleted/fake/scam
+   accounts, and writes a dry-run report to `data/{chat_username}/`.
+
+   **Actually add eligible users to contacts:**
+   ```zsh
+   bun add-chat-users-to-contacts.mjs --chat @your_chat_username --apply --limit 20
+   ```
+   The script uses Telegram's MTProto `contacts.addContact` method through your
+   user account. It does not require users' phone numbers. By default it does not
+   share your phone number; pass `--share-phone` only if you intentionally want
+   to allow added users to see it.
 
 3. If any required values are missing in `.env`, the script will prompt you interactively.
 

--- a/add-chat-users-to-contacts.mjs
+++ b/add-chat-users-to-contacts.mjs
@@ -1,0 +1,651 @@
+#!/usr/bin/env bun
+// add-chat-users-to-contacts.mjs
+//
+// Usage:
+//   bun add-chat-users-to-contacts.mjs --chat @group
+//   bun add-chat-users-to-contacts.mjs --chat @group --apply --limit 20
+//
+// The script collects users visible in a Telegram chat and adds eligible users
+// to the current account's Telegram contacts via contacts.addContact.
+
+import fs from 'fs';
+import path from 'path';
+
+const DEFAULT_DELAY_MS = 10000;
+const DEFAULT_PARTICIPANTS_LIMIT = 10000;
+const DEFAULT_MESSAGES_LIMIT = 100000;
+
+export function parseCliArgs(argv = process.argv.slice(2), env = process.env) {
+  const config = {
+    chat: env.TELEGRAM_CHAT_USERNAME || env.TELEGRAM_CHAT_ID || '',
+    apply: false,
+    dryRun: true,
+    help: false,
+    verbose: false,
+    sharePhone: false,
+    includeExisting: false,
+    limit: 0,
+    delayMs: DEFAULT_DELAY_MS,
+    participantsLimit: DEFAULT_PARTICIPANTS_LIMIT,
+    messagesLimit: DEFAULT_MESSAGES_LIMIT,
+  };
+
+  const isKnownOption = value => [
+    '--chat',
+    '--apply',
+    '--dry-run',
+    '--limit',
+    '--delay-ms',
+    '--participants-limit',
+    '--messages-limit',
+    '--share-phone',
+    '--include-existing',
+    '--verbose',
+    '-v',
+    '--help',
+    '-h',
+  ].includes(value);
+
+  const readValue = (index, flag) => {
+    const value = argv[index + 1];
+    if (value === undefined || isKnownOption(value)) {
+      throw new Error(`${flag} requires a value`);
+    }
+    return value;
+  };
+
+  const readNonNegativeInt = (value, flag) => {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      throw new Error(`${flag} must be a non-negative integer`);
+    }
+    return parsed;
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--chat':
+        config.chat = readValue(i, arg);
+        i++;
+        break;
+      case '--apply':
+        config.apply = true;
+        break;
+      case '--dry-run':
+        config.apply = false;
+        break;
+      case '--limit':
+        config.limit = readNonNegativeInt(readValue(i, arg), arg);
+        i++;
+        break;
+      case '--delay-ms':
+        config.delayMs = readNonNegativeInt(readValue(i, arg), arg);
+        i++;
+        break;
+      case '--participants-limit':
+        config.participantsLimit = readNonNegativeInt(readValue(i, arg), arg);
+        i++;
+        break;
+      case '--messages-limit':
+        config.messagesLimit = readNonNegativeInt(readValue(i, arg), arg);
+        i++;
+        break;
+      case '--share-phone':
+        config.sharePhone = true;
+        break;
+      case '--include-existing':
+        config.includeExisting = true;
+        break;
+      case '--verbose':
+      case '-v':
+        config.verbose = true;
+        break;
+      case '--help':
+      case '-h':
+        config.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  config.dryRun = !config.apply;
+  return config;
+}
+
+export function formatHelp() {
+  return `
+add-chat-users-to-contacts.mjs - Add visible Telegram chat users to contacts
+
+USAGE:
+  bun add-chat-users-to-contacts.mjs [OPTIONS]
+
+OPTIONS:
+  --chat <username|id|link>       Chat username, numeric ID, or t.me/c link
+  --apply                         Actually add contacts (default is dry-run)
+  --dry-run                       Preview actions without changing contacts
+  --limit <N>                     Max eligible users to process (0 = no limit)
+  --delay-ms <N>                  Delay between addContact calls (default: 10000)
+  --participants-limit <N>        Max participants to fetch (default: 10000)
+  --messages-limit <N>            Max messages to scan for users (default: 100000)
+  --include-existing              Include users already marked as contacts
+  --share-phone                   Allow added users to see your phone number
+  -v, --verbose                   Enable verbose logging
+  -h, --help                      Show this help message and exit
+
+ENVIRONMENT:
+  TELEGRAM_API_ID, TELEGRAM_API_HASH, TELEGRAM_PHONE
+  TELEGRAM_CHAT_USERNAME or TELEGRAM_CHAT_ID
+
+EXAMPLES:
+  bun add-chat-users-to-contacts.mjs --chat @mygroup
+  bun add-chat-users-to-contacts.mjs --chat @mygroup --apply --limit 20
+`;
+}
+
+export function sanitizeChatTarget(chat) {
+  const value = String(chat || '').trim();
+  const privateLinkMatch = value.match(/(?:https?:\/\/)?t\.me\/c\/(\d+)(?:\/\d+)?/i);
+  if (privateLinkMatch) {
+    return `-100${privateLinkMatch[1]}`;
+  }
+
+  const publicLinkMatch = value.match(/(?:https?:\/\/)?t\.me\/([A-Za-z0-9_]{5,})(?:\/\d+)?/i);
+  if (publicLinkMatch) {
+    return `@${publicLinkMatch[1]}`;
+  }
+
+  return value.replace(/[^\w@-]/g, '');
+}
+
+export function unwrapTelegramId(value) {
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'object') {
+    if ('value' in value) return unwrapTelegramId(value.value);
+    if ('userId' in value) return unwrapTelegramId(value.userId);
+    if ('id' in value) return unwrapTelegramId(value.id);
+  }
+  return value;
+}
+
+export function getUserIdKey(value) {
+  const id = unwrapTelegramId(value);
+  if (id === null || id === undefined || id === '') return null;
+  return String(id);
+}
+
+function userScore(user) {
+  if (!user || typeof user !== 'object') return 0;
+  let score = 1;
+  if (user.accessHash || user.access_hash) score += 5;
+  if (user.username) score += 3;
+  if (user.firstName || user.lastName) score += 2;
+  if (user.phone) score += 1;
+  return score;
+}
+
+function rememberUser(usersById, user, source) {
+  if (!user || typeof user !== 'object') return false;
+  if (user.className === 'Channel' || user.className === 'Chat') return false;
+  const key = getUserIdKey(user);
+  if (!key) return false;
+
+  const existing = usersById.get(key);
+  if (existing) {
+    existing.sources.add(source);
+    if (userScore(user) > userScore(existing.user)) {
+      existing.user = user;
+    }
+    return false;
+  }
+
+  usersById.set(key, {
+    key,
+    user,
+    sources: new Set([source]),
+  });
+  return true;
+}
+
+function rememberUserId(idsByKey, value, source) {
+  const key = getUserIdKey(value);
+  if (!key) return;
+  if (!idsByKey.has(key)) {
+    idsByKey.set(key, { id: unwrapTelegramId(value), sources: new Set() });
+  }
+  idsByKey.get(key).sources.add(source);
+}
+
+export function shouldAddContactCandidate(user, { meId, includeExisting = false } = {}) {
+  if (!user || typeof user !== 'object') return { ok: false, reason: 'no-user' };
+  if (user.className === 'Channel' || user.className === 'Chat') {
+    return { ok: false, reason: 'non-user' };
+  }
+
+  const userKey = getUserIdKey(user);
+  if (!userKey) return { ok: false, reason: 'no-id' };
+  if (meId !== undefined && meId !== null && userKey === getUserIdKey(meId)) {
+    return { ok: false, reason: 'self' };
+  }
+
+  if (user.bot === true) return { ok: false, reason: 'bot' };
+  if (user.deleted === true) return { ok: false, reason: 'deleted' };
+  if (user.fake === true) return { ok: false, reason: 'fake' };
+  if (user.scam === true) return { ok: false, reason: 'scam' };
+  if (user.support === true) return { ok: false, reason: 'support' };
+  if (user.contact === true && !includeExisting) return { ok: false, reason: 'already-contact' };
+
+  return { ok: true, reason: 'eligible' };
+}
+
+function cleanName(value) {
+  return String(value || '').trim();
+}
+
+export function buildAddContactRequestArgs(user, { sharePhone = false } = {}) {
+  let firstName = cleanName(user.firstName);
+  let lastName = cleanName(user.lastName);
+
+  if (!firstName && lastName) {
+    firstName = lastName;
+    lastName = '';
+  }
+
+  if (!firstName && user.username) {
+    firstName = cleanName(user.username).replace(/^@/, '');
+  }
+
+  if (!firstName) {
+    firstName = `User ${getUserIdKey(user) || 'unknown'}`;
+  }
+
+  return {
+    id: user,
+    firstName,
+    lastName,
+    phone: cleanName(user.phone),
+    addPhonePrivacyException: Boolean(sharePhone),
+  };
+}
+
+export function createJsonReplacer() {
+  return (key, value) => {
+    if (typeof value === 'bigint') return value.toString();
+    if (value instanceof Set) return Array.from(value);
+    return value;
+  };
+}
+
+export function parseFloodWaitSeconds(err) {
+  if (!err) return null;
+  for (const field of ['seconds', 'value']) {
+    if (Number.isFinite(err[field]) && err[field] > 0) return err[field];
+  }
+
+  const texts = [
+    err.message,
+    err.errorMessage,
+    err.originalError?.message,
+    typeof err.toString === 'function' ? err.toString() : '',
+  ].filter(Boolean);
+
+  for (const text of texts) {
+    const floodMatch = String(text).match(/FLOOD_(?:PREMIUM_)?WAIT_(\d+)/i);
+    if (floodMatch) return Number.parseInt(floodMatch[1], 10);
+
+    const waitMatch = String(text).match(/wait of (\d+) seconds/i);
+    if (waitMatch) return Number.parseInt(waitMatch[1], 10);
+  }
+
+  return null;
+}
+
+export function extractUserIdsFromMessage(message) {
+  const ids = [];
+  const add = (value) => {
+    if (getUserIdKey(value)) ids.push(value);
+  };
+
+  add(message.senderId);
+
+  const action = message.action;
+  if (action) {
+    if (action.className === 'MessageActionChatJoinedByLink' ||
+        action.className === 'MessageActionChatJoinedByRequest') {
+      add(message.senderId);
+    }
+
+    if (action.className === 'MessageActionChatAddUser' && action.users) {
+      action.users.forEach(add);
+    }
+
+    if (action.className === 'MessageActionChatDeleteUser') {
+      add(action.userId);
+    }
+
+    if (action.className === 'MessageActionChatCreate' && action.users) {
+      action.users.forEach(add);
+    }
+  }
+
+  const fromId = message.fwdFrom?.fromId;
+  if (fromId?.userId) add(fromId.userId);
+
+  if (message.entities) {
+    for (const entity of message.entities) {
+      if (entity.className === 'MessageEntityMentionName') add(entity.userId);
+      if (entity.className === 'InputMessageEntityMentionName') add(entity.userId);
+    }
+  }
+
+  if (message.media?.className === 'MessageMediaContact') {
+    add(message.media.userId);
+  }
+
+  return ids;
+}
+
+function makeLogger(verbose) {
+  return {
+    verbose: (...msgs) => { if (verbose) console.log('[VERBOSE]', ...msgs); },
+    info: (...msgs) => console.log(...msgs),
+    warn: (...msgs) => console.warn(...msgs),
+    error: (...msgs) => console.error(...msgs),
+  };
+}
+
+function getDisplayName(user) {
+  if (!user || typeof user !== 'object') return 'unknown';
+  if (user.username) return `@${user.username}`;
+  const name = `${user.firstName || ''} ${user.lastName || ''}`.trim();
+  return name || `ID:${getUserIdKey(user) || 'unknown'}`;
+}
+
+function summarizeRecord(record, status, reason = null) {
+  const user = record.user;
+  return {
+    id: getUserIdKey(user),
+    username: user.username || null,
+    firstName: user.firstName || null,
+    lastName: user.lastName || null,
+    displayName: getDisplayName(user),
+    contact: user.contact === true,
+    bot: user.bot === true,
+    deleted: user.deleted === true,
+    fake: user.fake === true,
+    scam: user.scam === true,
+    sources: Array.from(record.sources).sort(),
+    status,
+    reason,
+  };
+}
+
+async function collectVisibleUsers(client, entity, config, log) {
+  const usersById = new Map();
+  const idsByKey = new Map();
+
+  log.info('Fetching visible chat participants...');
+  try {
+    let count = 0;
+    const params = config.participantsLimit > 0 ? { limit: config.participantsLimit } : {};
+    for await (const participant of client.iterParticipants(entity, params)) {
+      rememberUser(usersById, participant, 'participants');
+      count++;
+      if (count % 500 === 0) {
+        log.info(`Fetched ${count} participants, ${usersById.size} unique users so far...`);
+      }
+    }
+    log.info(`Fetched ${count} participants.`);
+  } catch (err) {
+    log.warn(`Could not fetch participants: ${err.message}`);
+    log.verbose(err.stack || err);
+  }
+
+  if (config.messagesLimit > 0) {
+    log.info('Scanning messages for additional visible users...');
+    try {
+      let count = 0;
+      for await (const message of client.iterMessages(entity, { limit: config.messagesLimit })) {
+        count++;
+        if (message.sender && message.sender.className !== 'Channel' && message.sender.className !== 'Chat') {
+          rememberUser(usersById, message.sender, 'message.sender');
+        }
+
+        for (const userId of extractUserIdsFromMessage(message)) {
+          rememberUserId(idsByKey, userId, 'message');
+        }
+
+        if (count % 1000 === 0) {
+          log.info(`Scanned ${count} messages, ${usersById.size} unique resolved users so far...`);
+        }
+      }
+      log.info(`Scanned ${count} messages.`);
+    } catch (err) {
+      log.warn(`Could not scan messages: ${err.message}`);
+      log.verbose(err.stack || err);
+    }
+  }
+
+  const unresolved = Array.from(idsByKey.values())
+    .filter(({ id }) => !usersById.has(getUserIdKey(id)));
+
+  if (unresolved.length > 0) {
+    log.info(`Resolving ${unresolved.length} user IDs from messages...`);
+    let resolved = 0;
+    let failed = 0;
+    for (const item of unresolved) {
+      try {
+        const user = await client.getEntity(item.id);
+        const added = rememberUser(usersById, user, Array.from(item.sources).join(', '));
+        if (added) resolved++;
+      } catch (err) {
+        failed++;
+        log.verbose(`Could not resolve user ${String(item.id)}: ${err.message}`);
+      }
+
+      if ((resolved + failed) % 50 === 0) {
+        log.info(`Resolved ${resolved}/${unresolved.length} user IDs (${failed} failed)...`);
+      }
+
+      if (unresolved.length > 10) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+    }
+    log.info(`User ID resolution complete: ${resolved} resolved, ${failed} failed.`);
+  }
+
+  return Array.from(usersById.values());
+}
+
+function normalizeError(err) {
+  return {
+    name: err?.name || null,
+    message: err?.message || String(err),
+    code: err?.code || err?.errorCode || null,
+    seconds: parseFloodWaitSeconds(err),
+  };
+}
+
+async function invokeAddContactWithFloodWait(client, Api, args, log) {
+  try {
+    return await client.invoke(new Api.contacts.AddContact(args));
+  } catch (err) {
+    const waitSeconds = parseFloodWaitSeconds(err);
+    if (!waitSeconds) throw err;
+
+    log.warn(`Telegram requested FLOOD_WAIT_${waitSeconds}; waiting before retrying this contact.`);
+    await new Promise(resolve => setTimeout(resolve, (waitSeconds + 1) * 1000));
+    return await client.invoke(new Api.contacts.AddContact(args));
+  }
+}
+
+function getChatFolderName(entity, fallback) {
+  const raw = entity?.username || entity?.title || fallback || entity?.id || 'unknown_chat';
+  return String(raw).replace(/[^a-zA-Z0-9_-]/g, '_').toLowerCase() || 'unknown_chat';
+}
+
+function writeReport(entity, chatTarget, report) {
+  const folder = getChatFolderName(entity, chatTarget);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').substring(0, 19);
+  const outDir = path.join('data', folder);
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, `contact-add-report-${timestamp}.json`);
+  fs.writeFileSync(outPath, JSON.stringify(report, createJsonReplacer(), 2));
+  return outPath;
+}
+
+async function runCli(config) {
+  const log = makeLogger(config.verbose);
+  const { usingTelegram, use } = await import('./utils.mjs');
+
+  let chatTarget = config.chat;
+  if (!chatTarget) {
+    const input = await use('readline-sync');
+    chatTarget = input.question('Enter chat username (with @), chat ID, or t.me/c link: ');
+  }
+  chatTarget = sanitizeChatTarget(chatTarget);
+  if (!chatTarget) {
+    throw new Error('Chat target is required. Use --chat or TELEGRAM_CHAT_USERNAME/TELEGRAM_CHAT_ID.');
+  }
+
+  const originalWarningListeners = process.listeners('warning');
+  process.removeAllListeners('warning');
+  process.on('warning', (warning) => {
+    if (warning.name === 'TimeoutNegativeWarning') return;
+    originalWarningListeners.forEach(listener => listener(warning));
+  });
+
+  await usingTelegram(async ({ client, Api }) => {
+    log.info('Connected.');
+    log.info(`Chat target: ${chatTarget}`);
+
+    const entity = await client.getEntity(chatTarget);
+    const me = await client.getMe();
+    const meId = unwrapTelegramId(me.id);
+    log.verbose(`Resolved chat entity: ${entity.className || 'Unknown'} ${entity.id || ''}`);
+
+    const records = await collectVisibleUsers(client, entity, config, log);
+    const skipped = [];
+    let eligible = [];
+
+    for (const record of records) {
+      const decision = shouldAddContactCandidate(record.user, {
+        meId,
+        includeExisting: config.includeExisting,
+      });
+
+      if (decision.ok) {
+        eligible.push(record);
+      } else {
+        skipped.push(summarizeRecord(record, 'skipped', decision.reason));
+      }
+    }
+
+    const eligibleBeforeLimit = eligible.length;
+    if (config.limit > 0) {
+      eligible = eligible.slice(0, config.limit);
+    }
+
+    log.info(`Found ${records.length} visible unique users.`);
+    log.info(`Eligible to add: ${eligible.length}${config.limit > 0 ? ` of ${eligibleBeforeLimit} before --limit` : ''}.`);
+    log.info(`Skipped: ${skipped.length}.`);
+
+    const results = [];
+    if (config.dryRun) {
+      log.info('Dry-run mode: no contacts will be changed. Use --apply to add contacts.');
+      for (const record of eligible) {
+        results.push(summarizeRecord(record, 'dry-run', 'eligible'));
+      }
+    } else {
+      log.info('Apply mode: adding eligible users to contacts.');
+      for (let index = 0; index < eligible.length; index++) {
+        const record = eligible[index];
+        const user = record.user;
+        const args = buildAddContactRequestArgs(user, { sharePhone: config.sharePhone });
+        const summary = summarizeRecord(record, 'pending');
+        summary.contactFirstName = args.firstName;
+        summary.contactLastName = args.lastName;
+
+        try {
+          await invokeAddContactWithFloodWait(client, Api, args, log);
+          summary.status = 'added';
+          summary.reason = null;
+          log.info(`[${index + 1}/${eligible.length}] Added ${getDisplayName(user)}`);
+        } catch (err) {
+          summary.status = 'failed';
+          summary.reason = normalizeError(err);
+          log.warn(`[${index + 1}/${eligible.length}] Failed ${getDisplayName(user)}: ${err.message}`);
+        }
+
+        results.push(summary);
+
+        if (config.delayMs > 0 && index < eligible.length - 1) {
+          await new Promise(resolve => setTimeout(resolve, config.delayMs));
+        }
+      }
+    }
+
+    const counts = {
+      visibleUsers: records.length,
+      eligibleBeforeLimit,
+      processed: eligible.length,
+      skipped: skipped.length,
+      dryRun: results.filter(item => item.status === 'dry-run').length,
+      added: results.filter(item => item.status === 'added').length,
+      failed: results.filter(item => item.status === 'failed').length,
+    };
+
+    const report = {
+      generatedAt: new Date().toISOString(),
+      mode: config.dryRun ? 'dry-run' : 'apply',
+      chat: {
+        target: chatTarget,
+        id: getUserIdKey(entity),
+        title: entity.title || null,
+        username: entity.username || null,
+        className: entity.className || null,
+      },
+      options: {
+        limit: config.limit,
+        delayMs: config.delayMs,
+        participantsLimit: config.participantsLimit,
+        messagesLimit: config.messagesLimit,
+        includeExisting: config.includeExisting,
+        sharePhone: config.sharePhone,
+      },
+      counts,
+      results,
+      skipped,
+    };
+
+    const reportPath = writeReport(entity, chatTarget, report);
+    log.info(`Report saved to ${reportPath}`);
+  });
+}
+
+function isMainModule() {
+  if (typeof Bun !== 'undefined' && Bun.main) {
+    return path.resolve(Bun.main) === path.resolve(new URL(import.meta.url).pathname);
+  }
+  if (process.argv[1]) {
+    return path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname);
+  }
+  return false;
+}
+
+if (isMainModule()) {
+  try {
+    const config = parseCliArgs();
+    if (config.help) {
+      console.log(formatHelp());
+      process.exit(0);
+    }
+
+    await runCli(config);
+    process.exit(0);
+  } catch (err) {
+    console.error('Error:', err.message || err);
+    process.exit(1);
+  }
+}

--- a/docs/case-studies/issue-13/README.md
+++ b/docs/case-studies/issue-13/README.md
@@ -1,0 +1,215 @@
+# Case Study: Issue #13 - Add Chat Users To Contacts
+
+## Summary
+
+Issue #13 asks for automation that adds users from a Telegram chat to the current account's contact list, so those users can more easily open private conversations with the account. The issue also explicitly requires a repository-local case study with online research, requirement extraction, solution options, and a single pull request implementation.
+
+This PR implements a new `add-chat-users-to-contacts.mjs` script and documents the research behind the approach.
+
+## Requirements
+
+1. Compile issue-related data under `docs/case-studies/issue-13`.
+2. Perform a deeper case study analysis using repository context and online facts.
+3. List every requirement from the issue.
+4. Propose possible solutions and solution plans for each requirement.
+5. Check existing components and libraries that solve, or help solve, the problem.
+6. Execute the selected solution in one pull request.
+7. Add a script that automates adding chat users into contacts.
+8. Avoid a workflow that requires manually adding each chat user.
+
+## Repository Findings
+
+The repository already uses a user account through GramJS, not a Telegram Bot API token:
+
+- `utils.mjs` initializes a `TelegramClient` and stores `.telegram_session`.
+- `chat-users.mjs` already discovers users from participants, message authors, service actions, forwards, mentions, and shared contact media.
+- `message-members.mjs` already filters out bots, deleted, fake, and scam accounts before private-message operations.
+- Existing tests use `bun:test` and import pure helpers from ESM scripts.
+
+These patterns make a GramJS-based script the lowest-risk implementation path.
+
+## Online Research Findings
+
+### Telegram Contact APIs
+
+Telegram documents two relevant MTProto contact workflows:
+
+- `contacts.importContacts` imports phone contacts using `inputPhoneContact` values. It needs phone numbers and is intended for syncing a local address book. Source: https://core.telegram.org/api/contacts
+- `contacts.addContact` adds an existing Telegram user as a contact, and Telegram explicitly says it can work without knowing the user's phone number. Source: https://core.telegram.org/api/contacts and https://core.telegram.org/method/contacts.addContact
+
+The `contacts.addContact` method parameters include:
+
+- `id`: the target `InputUser`
+- `first_name` and `last_name`
+- `phone`, which Telegram says may be omitted to add without a phone number
+- `add_phone_privacy_exception`, which allows the other user to see our phone number if enabled
+
+The method is marked "Only users can use this method", so a Bot API implementation is not suitable for this exact requirement. Source: https://core.telegram.org/method/contacts.addContact
+
+### GramJS Support
+
+GramJS exposes `Api.contacts.AddContact` with camelCase arguments (`firstName`, `lastName`, `addPhonePrivacyException`) and accepts an entity-like `id`. Source: https://gram.js.org/tl/contacts/AddContact
+
+GramJS also supports `iterParticipants` for participant discovery in groups and channels, which matches the existing `chat-users.mjs` approach. Source: https://painor.gitbook.io/gramjs/getting-started/available-methods/getting-participants-of-a-group-channel
+
+### Telegram Constraints
+
+Participant discovery is not guaranteed to return every historical user:
+
+- Channel or supergroup participant access can be limited by Telegram permissions and privacy.
+- Message scanning can find additional users from senders, service actions, forwards, mentions, and contact media.
+- Some users may be inaccessible, deleted, bots, or already contacts.
+- Telegram can return flood-wait errors for repeated API actions. The script should delay requests and respect flood-wait responses.
+
+### Privacy Constraint
+
+The script must not share the current account's phone number by default. Telegram's `add_phone_privacy_exception` flag exists specifically for allowing the other user to see the phone number, so the safe default is `false`. The implementation exposes this only as an explicit `--share-phone` option.
+
+## Existing Components And Library Options
+
+### Option A: GramJS In This Repository
+
+Use the current `telegram` package through `use-m`, the existing `.telegram_session`, and `Api.contacts.AddContact`.
+
+Pros:
+
+- Matches current repo architecture.
+- No package manager setup required.
+- Reuses Telegram login/session flow.
+- Supports the exact official MTProto method required.
+
+Cons:
+
+- Uses a user account, so real runs affect the operator's Telegram contacts.
+- Needs rate limiting and dry-run behavior.
+
+Chosen for this PR.
+
+### Option B: Extend `chat-users.mjs` Output
+
+Run `chat-users.mjs`, then add contacts from `data/{chat}/users.json`.
+
+Pros:
+
+- Separates discovery from mutation.
+- Lets the user review discovered users first.
+
+Cons:
+
+- The existing JSON output does not preserve access hashes or full input entities.
+- Numeric IDs alone are often not enough to call `contacts.addContact`.
+- Adds a fragile two-step workflow.
+
+Useful as a future enhancement if `chat-users.mjs` starts writing enough entity metadata.
+
+### Option C: Phone Contact Import
+
+Use `contacts.importContacts` or a wrapper library's import contacts helper.
+
+Pros:
+
+- Good for a trusted phone-number list.
+- Official Telegram workflow.
+
+Cons:
+
+- Does not solve the main chat-user case when phone numbers are unavailable.
+- More likely to expose or depend on phone address book data.
+
+Rejected for the primary workflow.
+
+### Option D: Bot API
+
+Use a Telegram bot to add contacts.
+
+Pros:
+
+- Bot token setup can be simpler for many automations.
+
+Cons:
+
+- Telegram marks `contacts.addContact` as user-only.
+- Bot API does not provide an equivalent "add this user to my contacts" operation.
+
+Rejected.
+
+### Option E: Other MTProto Libraries
+
+Telethon, Pyrogram/Hydrogram, TDLib, and MadelineProto expose raw MTProto contact methods.
+
+Pros:
+
+- Mature alternatives exist in Python, C++/JSON, and PHP ecosystems.
+
+Cons:
+
+- This repository is already JavaScript/Bun and GramJS-based.
+- Switching libraries would add unnecessary runtime and session complexity.
+
+Not chosen for this PR.
+
+## Selected Solution
+
+Add `add-chat-users-to-contacts.mjs`:
+
+1. Parse CLI options before any Telegram connection, so `--help` is safe.
+2. Default to dry-run mode.
+3. Require `--apply` before mutating the Telegram contact list.
+4. Resolve the target chat from `--chat`, `TELEGRAM_CHAT_USERNAME`, `TELEGRAM_CHAT_ID`, or an interactive prompt.
+5. Collect visible users from `iterParticipants`.
+6. Scan messages for additional sender, service-action, forward, mention, and shared-contact user IDs.
+7. Resolve message-only user IDs where Telegram allows it.
+8. Skip self, bots, deleted, fake, scam, support accounts, and existing contacts by default.
+9. Build non-empty `contacts.addContact` names, falling back to username or `User {id}`.
+10. Add contacts through `Api.contacts.AddContact` only in `--apply` mode.
+11. Use a delay between mutations and retry once after Telegram flood-wait responses.
+12. Write a JSON report to `data/{chat}/contact-add-report-{timestamp}.json`.
+
+## Usage
+
+Preview only:
+
+```zsh
+bun add-chat-users-to-contacts.mjs --chat @your_chat_username
+```
+
+Apply a limited batch:
+
+```zsh
+bun add-chat-users-to-contacts.mjs --chat @your_chat_username --apply --limit 20
+```
+
+Apply and intentionally allow added users to see your phone number:
+
+```zsh
+bun add-chat-users-to-contacts.mjs --chat @your_chat_username --apply --share-phone
+```
+
+## Verification Plan
+
+Automated tests cover the pure parts of the new script:
+
+- CLI parsing defaults to dry-run.
+- `--apply`, limits, delays, and privacy flags parse correctly.
+- `t.me/c` links normalize to Telegram private chat IDs.
+- GramJS BigInt-like IDs normalize safely.
+- Candidate filtering skips unsafe or irrelevant accounts.
+- `contacts.addContact` arguments never use an empty first name.
+- JSON reports serialize BigInt IDs.
+- Flood-wait seconds are parsed from Telegram-style errors.
+
+Manual live verification requires valid Telegram credentials and a real chat. The safe command is the dry-run command above, because it connects and scans without changing contacts.
+
+## Follow-Up Ideas
+
+- Add `--from-users-json` if `chat-users.mjs` is later extended to preserve enough entity information for reliable contact addition.
+- Add resumable apply reports that can skip users already processed in a prior report.
+- Add a configurable maximum flood-wait threshold for unattended runs.
+
+## References
+
+- Telegram Core API contacts overview: https://core.telegram.org/api/contacts
+- Telegram `contacts.addContact`: https://core.telegram.org/method/contacts.addContact
+- GramJS `contacts.AddContact`: https://gram.js.org/tl/contacts/AddContact
+- GramJS participants helper: https://painor.gitbook.io/gramjs/getting-started/available-methods/getting-participants-of-a-group-channel
+- Telegram channels and supergroups behavior: https://core.telegram.org/api/channel

--- a/docs/case-studies/issue-13/issue-details.md
+++ b/docs/case-studies/issue-13/issue-details.md
@@ -1,0 +1,34 @@
+# Issue #13 Data
+
+## GitHub Metadata
+
+- Issue: https://github.com/konard/telegram-bot/issues/13
+- Title: We need a script, to add all chat users into contacts, so they can freely access my private messages
+- Author: konard
+- Created: 2026-05-08T05:52:08Z
+- Updated: 2026-05-08T05:52:08Z
+- State at implementation time: open
+- Labels: documentation, enhancement
+- Prepared PR: https://github.com/konard/telegram-bot/pull/14
+- Branch: issue-13-83ec1ed74413
+
+## Original Issue Body
+
+> I want to automate manual routing of adding list of users in chat to contacts, if I do it manually it takes a lot of time, which can be free to do something more valuable.
+>
+> We need to collect data related about the issue to this repository, make sure we compile that data to `./docs/case-studies/issue-{id}` folder, and use it to do deep case study analysis (also make sure to search online for additional facts and data), list of each and all requirements from the issue, and propose possible solutions and solution plans for each requirement (we should also check known existing components/libraries, that solve similar problem or can help in solutions).
+>
+> Please plan and execute everything in a single pull request, you have unlimited time and context, as context auto-compacts and you can continue indefinitely, until it is each and every requirement fully addressed, and everything is totally done.
+
+## Comments And Reviews
+
+- Issue comments: none at implementation time.
+- PR conversation comments: none at implementation time.
+- PR review comments: none at implementation time.
+- PR reviews: none at implementation time.
+
+## Related Repository Context
+
+- `chat-users.mjs` already extracts unique users from a chat using participants, message authors, service events, forwards, mentions, and shared contacts.
+- `message-members.mjs` already demonstrates iterating chat participants and filtering bots/deleted/fake/scam accounts before private-message operations.
+- Prior case studies exist under `docs/case-studies/issue-5` and `docs/case-studies/issue-7`, both focused on Telegram user extraction behavior and GramJS runtime issues.

--- a/tests/add-chat-users-to-contacts.test.mjs
+++ b/tests/add-chat-users-to-contacts.test.mjs
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  buildAddContactRequestArgs,
+  createJsonReplacer,
+  getUserIdKey,
+  parseCliArgs,
+  parseFloodWaitSeconds,
+  sanitizeChatTarget,
+  shouldAddContactCandidate,
+  unwrapTelegramId,
+} from '../add-chat-users-to-contacts.mjs';
+
+describe('parseCliArgs', () => {
+  it('defaults to dry-run mode unless --apply is present', () => {
+    const config = parseCliArgs(['--chat', '@team']);
+    expect(config.chat).toBe('@team');
+    expect(config.apply).toBe(false);
+    expect(config.dryRun).toBe(true);
+    expect(config.delayMs).toBe(10000);
+  });
+
+  it('parses apply, limits, delay, phone sharing, and verbose flags', () => {
+    const config = parseCliArgs([
+      '--chat', '@team',
+      '--apply',
+      '--limit', '25',
+      '--delay-ms', '5000',
+      '--participants-limit', '100',
+      '--messages-limit', '200',
+      '--share-phone',
+      '--verbose',
+    ]);
+
+    expect(config.apply).toBe(true);
+    expect(config.dryRun).toBe(false);
+    expect(config.limit).toBe(25);
+    expect(config.delayMs).toBe(5000);
+    expect(config.participantsLimit).toBe(100);
+    expect(config.messagesLimit).toBe(200);
+    expect(config.sharePhone).toBe(true);
+    expect(config.verbose).toBe(true);
+  });
+
+  it('allows negative Telegram chat IDs as --chat values', () => {
+    const config = parseCliArgs(['--chat', '-1001234567890']);
+    expect(config.chat).toBe('-1001234567890');
+  });
+});
+
+describe('sanitizeChatTarget', () => {
+  it('converts private t.me/c links to -100 chat IDs', () => {
+    expect(sanitizeChatTarget('https://t.me/c/123456/789')).toBe('-100123456');
+  });
+
+  it('keeps usernames and strips unsafe characters', () => {
+    expect(sanitizeChatTarget('@my-team!!')).toBe('@my-team');
+  });
+});
+
+describe('Telegram ID helpers', () => {
+  it('unwraps BigInt-like GramJS integer values', () => {
+    expect(unwrapTelegramId({ value: 123n })).toBe(123n);
+  });
+
+  it('creates stable string keys for primitive and wrapped IDs', () => {
+    expect(getUserIdKey(123n)).toBe('123');
+    expect(getUserIdKey({ value: 456n })).toBe('456');
+    expect(getUserIdKey(null)).toBeNull();
+  });
+});
+
+describe('shouldAddContactCandidate', () => {
+  const meId = 100n;
+
+  it('accepts regular non-contact users', () => {
+    const result = shouldAddContactCandidate({ id: 200n, firstName: 'Ada' }, { meId });
+    expect(result).toEqual({ ok: true, reason: 'eligible' });
+  });
+
+  it('skips the current account', () => {
+    const result = shouldAddContactCandidate({ id: 100n, firstName: 'Me' }, { meId });
+    expect(result).toEqual({ ok: false, reason: 'self' });
+  });
+
+  it('skips bots, deleted, fake, scam, and support accounts', () => {
+    expect(shouldAddContactCandidate({ id: 1, bot: true }, { meId }).reason).toBe('bot');
+    expect(shouldAddContactCandidate({ id: 2, deleted: true }, { meId }).reason).toBe('deleted');
+    expect(shouldAddContactCandidate({ id: 3, fake: true }, { meId }).reason).toBe('fake');
+    expect(shouldAddContactCandidate({ id: 4, scam: true }, { meId }).reason).toBe('scam');
+    expect(shouldAddContactCandidate({ id: 5, support: true }, { meId }).reason).toBe('support');
+  });
+
+  it('skips existing contacts by default but can include them', () => {
+    const user = { id: 300n, contact: true, firstName: 'Existing' };
+    expect(shouldAddContactCandidate(user, { meId }).reason).toBe('already-contact');
+    expect(shouldAddContactCandidate(user, { meId, includeExisting: true }).ok).toBe(true);
+  });
+});
+
+describe('buildAddContactRequestArgs', () => {
+  it('builds contacts.addContact arguments without requiring a phone number', () => {
+    const user = { id: 123n, username: 'ada_dev', firstName: '', lastName: '' };
+    const args = buildAddContactRequestArgs(user, { sharePhone: false });
+
+    expect(args.id).toBe(user);
+    expect(args.firstName).toBe('ada_dev');
+    expect(args.lastName).toBe('');
+    expect(args.phone).toBe('');
+    expect(args.addPhonePrivacyException).toBe(false);
+  });
+
+  it('guarantees a non-empty contact name when Telegram user names are absent', () => {
+    const args = buildAddContactRequestArgs({ id: 12345n }, { sharePhone: false });
+    expect(args.firstName).toBe('User 12345');
+  });
+
+  it('can opt in to phone privacy exception', () => {
+    const args = buildAddContactRequestArgs({ id: 1, firstName: 'Ada' }, { sharePhone: true });
+    expect(args.addPhonePrivacyException).toBe(true);
+  });
+});
+
+describe('report serialization and flood waits', () => {
+  it('serializes BigInt values in JSON reports', () => {
+    const json = JSON.stringify({ id: 123n }, createJsonReplacer(), 2);
+    expect(json).toContain('"123"');
+  });
+
+  it('extracts FLOOD_WAIT seconds from Telegram errors', () => {
+    expect(parseFloodWaitSeconds({ seconds: 5 })).toBe(5);
+    expect(parseFloodWaitSeconds({ message: 'FLOOD_WAIT_17' })).toBe(17);
+    expect(parseFloodWaitSeconds({ errorMessage: 'A wait of 23 seconds is required' })).toBe(23);
+    expect(parseFloodWaitSeconds({ message: 'CONTACT_ID_INVALID' })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `add-chat-users-to-contacts.mjs`, a dry-run-first GramJS script that collects visible chat users and adds eligible users with `contacts.addContact` only when `--apply` is passed.
- Filter self, bots, deleted, fake, scam, support accounts, and existing contacts by default; keep phone sharing opt-in through `--share-phone`.
- Write BigInt-safe dry-run/apply reports under `data/{chat}/`.
- Add `docs/case-studies/issue-13` with issue data, official Telegram/GramJS research, requirements, alternatives, and the selected plan.
- Document usage in `README.md` and remove the initial `.gitkeep` placeholder.

## How to reproduce / use

Preview without changing contacts:

```zsh
bun add-chat-users-to-contacts.mjs --chat @your_chat_username
```

Apply a limited batch:

```zsh
bun add-chat-users-to-contacts.mjs --chat @your_chat_username --apply --limit 20
```

Live dry-run/apply verification requires valid Telegram credentials and a real chat.

## Verification

- `bun test`
- `bun add-chat-users-to-contacts.mjs --help`

Fixes #13